### PR TITLE
Changes to work with elasticsearch 5.2

### DIFF
--- a/es-reindex.rb
+++ b/es-reindex.rb
@@ -100,10 +100,13 @@ unless retried_request(:get, "#{durl}/#{didx}/_recovery")
   end
   settings = Oj.load settings
   sidx = settings.keys[0]
-  settings[sidx].delete 'index.version.created'
+  settings[sidx]['settings']['index'].delete 'creation_date'
+  settings[sidx]['settings']['index'].delete 'uuid'
+  settings[sidx]['settings']['index'].delete 'version'
+
   printf 'Creating \'%s/%s\' index with settings from \'%s/%s\'... ',
       durl, didx, surl, sidx
-  unless retried_request(:post, "#{durl}/#{didx}", Oj.dump(settings[sidx]))
+  unless retried_request(:put, "#{durl}/#{didx}", Oj.dump(settings[sidx]))
     puts 'FAILED!'
     exit 1
   else


### PR DESCRIPTION
A beginning of the changes to work with elasticsearch 5.2

Other changes that need to go in:
* Remove the "fielddata" type from almost every property deep down under mappings[sidx]
* search_type=scan is now gone, I *think* the replacement is to specify a size on the search request. 